### PR TITLE
Add System:Remark to NestingSupported list

### DIFF
--- a/app/src/substrate_dispatch_V8.c
+++ b/app/src/substrate_dispatch_V8.c
@@ -6665,6 +6665,7 @@ bool _getMethod_IsNestingSupported_V8(uint8_t moduleIdx, uint8_t callIdx)
     uint16_t callPrivIdx = ((uint16_t)moduleIdx << 8u) + callIdx;
 
     switch (callPrivIdx) {
+    case 1: // System:Remark
     case 9: // System:Remark with event
     case 256: // Scheduler:Schedule
     case 257: // Scheduler:Cancel


### PR DESCRIPTION
I was surprised by the fact that the "system:remark" is not in the nesting list but "system:remark with the event" is in.
Also I was surprized that Nano X supports adding "system:remark" into a batch of calls, but the default Nano S app version doesn't
We released mechanics which use this "system:remark" in a batch of calls because we tested it on Nano X and it's worked fine. Now we have to recommend our users installing the Polkadot XL app to use our mechanic.