### PR TITLE
Swap segfault lns

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -131,7 +131,20 @@ endif
 ############
 # Platform
 
-DEFINES       += PRINTF\(...\)=
+ifndef DEBUG
+	DEBUG = 0
+endif
+
+ifneq ($(DEBUG),0)
+	DEFINES += HAVE_PRINTF
+	ifeq ($(TARGET_NAME),TARGET_NANOS)
+    	DEFINES += PRINTF=screen_printf
+	else
+    	DEFINES += PRINTF=mcu_usb_printf
+    endif
+else
+    DEFINES += PRINTF\(...\)=
+endif
 
 APPVERSION=$(APPVERSION_M).$(APPVERSION_N).$(APPVERSION_P)
 DEFINES       += APPVERSION=\"$(APPVERSION)\"

--- a/app/src/common/main.c
+++ b/app/src/common/main.c
@@ -49,7 +49,6 @@ main(int arg0) {
     // exit critical section
     __asm volatile("cpsie i");
 
-    view_init();
     os_boot();
 
     if (!arg0) {
@@ -84,6 +83,7 @@ static void app_start(void) {
     {
         TRY
         {
+            view_init();
             app_init();
             app_main();
         }

--- a/app/src/swap/bip32_path.c
+++ b/app/src/swap/bip32_path.c
@@ -1,0 +1,19 @@
+#include "bip32_path.h"
+#include "os.h"
+
+bool parse_serialized_path(bip32_path_t* path,
+                           unsigned char* serialized_path,
+                           unsigned char serialized_path_length) {
+    if (serialized_path_length < 1 || serialized_path[0] > MAX_BIP32_PATH ||
+        serialized_path[0] * 4 + 1 > serialized_path_length)
+    {
+        return false;
+    }
+    
+    path->length = serialized_path[0];
+    serialized_path++;
+    for (int i = 0; i < path->length; i += 1, serialized_path += 4) {
+        path->path[i] = U4BE(serialized_path, 0);
+    }
+    return true;
+}

--- a/app/src/swap/bip32_path.h
+++ b/app/src/swap/bip32_path.h
@@ -1,0 +1,18 @@
+#ifndef _BIT32_PATH_H_
+#define _BIT32_PATH_H_
+
+#include "stdbool.h"
+
+#define MAX_BIP32_PATH        10
+#define MAX_BIP32_PATH_LENGTH (4 * MAX_BIP32_PATH) + 1
+
+typedef struct bip32_path {
+    unsigned char length;
+    unsigned int path[MAX_BIP32_PATH];
+} bip32_path_t;
+
+bool parse_serialized_path(bip32_path_t* path,
+                           unsigned char* serialized_path,
+                           unsigned char serialized_path_length);
+
+#endif //_BIT32_PATH_H_

--- a/app/src/swap/handle_check_address.c
+++ b/app/src/swap/handle_check_address.c
@@ -1,4 +1,17 @@
+#include <stdint.h>
+#include <string.h>
+
+#include <zxmacros.h>
 #include "handle_check_address.h"
+#include "bip32_path.h"
+#include "substrate_coin.h"
+#include "os.h"
+#include "os_seed.h"
+
+// static int os_strcmp(const char* s1, const char* s2) {
+//     size_t size = strlen(s1) + 1;
+//     return memcmp(s1, s2, size);
+// }
 
 int handle_check_address(check_address_parameters_t* params) {
     PRINTF("Params on the address %d\n", (unsigned int) params);
@@ -9,15 +22,82 @@ int handle_check_address(check_address_parameters_t* params) {
         return 0;
     }
 
-    // uint8_t i;
-    // const uint8_t* bip32_path_ptr = params->address_parameters;
-    // uint8_t bip32PathLength = *(bip32_path_ptr++);
-    // cx_sha3_t local_sha3;
-
-    // if (strcmp(locals_union1.address, params->address_to_check + offset_0x) != 0) {
-    //     PRINTF("Addresses don't match\n");
+    /** address_parameters :
+     * | address kind (1 byte) | path length (1 byte) | bip44 path (5 bytes) | 
+     */
+    /* Extract address kind */
+    //key_kind_e kind = (key_kind_e) *((params->address_parameters)++);
+    
+    /* Parse serialized path (extract path and path length) */
+    bip32_path_t path;
+    path.length = MAX_BIP32_PATH;
+    MEMZERO(path.path,sizeof(path.path));    
+    
+    // if (!parse_serialized_path(&path,
+    //                            params->address_parameters,
+    //                            params->address_parameters_length - 1)) // param length - 1B for path length)
+    // {
+    //     PRINTF("Can't parse path !\n");
     //     return 0;
     // }
-    // PRINTF("Addresses  match\n");
+
+    /* Generate public key from derivation path */
+    uint8_t pub_key[PK_LEN_25519] = {0};
+    //crypto_extractPublicKey(0, path.path, pub_key, PK_LEN_25519);
+
+    cx_ecfp_public_key_t cx_publicKey;
+    cx_ecfp_private_key_t cx_privateKey;
+    uint8_t privateKeyData[SK_LEN_25519];
+
+    // Generate keys
+    /* ==============================================================================
+     * ==============================================================================
+     * ==============================================================================
+     * ==============================================================================
+     * Calling os_perso_derive_node_bip32 and then cx_ecfp_generate_pair causes a segmentation fault in
+     * exchange app when coming back from the libcall and entering the apdu
+     * receiving loop of nanos-secure-sdk/src/os_io_seproxyhal.c at line 1217 (nanos sdk v2.1.0)
+     * ==============================================================================
+     * ==============================================================================
+     * ==============================================================================
+     * ==============================================================================
+     * ==============================================================================
+     */
+    os_perso_derive_node_bip32(
+            CX_CURVE_Ed25519,
+            path.path,
+            HDPATH_LEN_DEFAULT,
+            privateKeyData,
+            NULL);
+
+    cx_ecfp_init_private_key(CX_CURVE_Ed25519, privateKeyData, 32, &cx_privateKey);
+    cx_ecfp_init_public_key(CX_CURVE_Ed25519, NULL, 0, &cx_publicKey);
+    cx_ecfp_generate_pair(CX_CURVE_Ed25519, &cx_publicKey, &cx_privateKey, 1);
+    for (unsigned int i = 0; i < PK_LEN_25519; i++) {
+        pub_key[i] = cx_publicKey.W[64 - i];
+    }
+
+    if ((cx_publicKey.W[PK_LEN_25519] & 1) != 0) {
+        pub_key[31] |= 0x80;
+    }
+
+    // uint8_t addr[SS58_ADDRESS_MAX_LEN] = {0};
+    // size_t outLen = crypto_SS58EncodePubkey(addr,
+    //                                         SS58_ADDRESS_MAX_LEN,
+    //                                         PK_ADDRESS_TYPE, pub_key);
+    // if (outLen == 0) {
+    //     MEMZERO(pub_key, PK_LEN_25519);
+    //     MEMZERO(addr, SS58_ADDRESS_MAX_LEN);
+    //     PRINTF("Cannot generate address !\n");
+    //     return 0;
+    // }
+
+    /* Compare generated address with parameter address */
+    // if (os_strcmp((const char *) addr, params->address_to_check) != 0) {
+    //     PRINTF("Addresses don't match !\n");
+    //     //return 0;
+    // }
+    
+    PRINTF("Addresses match.\n");
     return 1;
 }

--- a/app/src/swap/handle_check_address.c
+++ b/app/src/swap/handle_check_address.c
@@ -1,0 +1,23 @@
+#include "handle_check_address.h"
+
+int handle_check_address(check_address_parameters_t* params) {
+    PRINTF("Params on the address %d\n", (unsigned int) params);
+    PRINTF("Address to check %s\n", params->address_to_check);
+    PRINTF("Inside handle_check_address\n");
+    if (params->address_to_check == 0) {
+        PRINTF("Address to check == 0\n");
+        return 0;
+    }
+
+    // uint8_t i;
+    // const uint8_t* bip32_path_ptr = params->address_parameters;
+    // uint8_t bip32PathLength = *(bip32_path_ptr++);
+    // cx_sha3_t local_sha3;
+
+    // if (strcmp(locals_union1.address, params->address_to_check + offset_0x) != 0) {
+    //     PRINTF("Addresses don't match\n");
+    //     return 0;
+    // }
+    // PRINTF("Addresses  match\n");
+    return 1;
+}

--- a/app/src/swap/handle_check_address.h
+++ b/app/src/swap/handle_check_address.h
@@ -1,0 +1,8 @@
+#ifndef _HANDLE_CHECK_ADDRESS_H_
+#define _HANDLE_CHECK_ADDRESS_H_
+
+#include "swap_lib_calls.h"
+
+int handle_check_address(check_address_parameters_t* check_address_params);
+
+#endif  // _HANDLE_CHECK_ADDRESS_H_

--- a/app/src/swap/handle_get_printable_amount.c
+++ b/app/src/swap/handle_get_printable_amount.c
@@ -1,0 +1,5 @@
+#include "handle_get_printable_amount.h"
+
+int handle_get_printable_amount(get_printable_amount_parameters_t* params) {
+    return 1;
+}

--- a/app/src/swap/handle_get_printable_amount.h
+++ b/app/src/swap/handle_get_printable_amount.h
@@ -1,0 +1,8 @@
+#ifndef _HANDLE_GET_PRINTABLE_AMOUNT_H_
+#define _HANDLE_GET_PRINTABLE_AMOUNT_H_
+
+#include "swap_lib_calls.h"
+
+int handle_get_printable_amount(get_printable_amount_parameters_t* get_printable_amount_params);
+
+#endif  // _HANDLE_GET_PRINTABLE_AMOUNT_H_

--- a/app/src/swap/handle_swap_sign_transaction.c
+++ b/app/src/swap/handle_swap_sign_transaction.c
@@ -1,0 +1,10 @@
+#include "handle_swap_sign_transaction.h"
+
+bool copy_transaction_parameters(create_transaction_parameters_t* sign_transaction_params) {
+
+    return true;
+}
+
+void handle_swap_sign_transaction(void) {
+
+}

--- a/app/src/swap/handle_swap_sign_transaction.h
+++ b/app/src/swap/handle_swap_sign_transaction.h
@@ -1,0 +1,10 @@
+#ifndef _HANDLE_SWAP_SIGN_TRANSACTION_H_
+#define _HANDLE_SWAP_SIGN_TRANSACTION_H_
+
+#include "swap_lib_calls.h"
+
+bool copy_transaction_parameters(create_transaction_parameters_t* sign_transaction_params);
+void handle_swap_sign_transaction(void);
+
+
+#endif  // _HANDLE_SWAP_SIGN_TRANSACTION_H_

--- a/app/src/swap/swap_lib_calls.h
+++ b/app/src/swap/swap_lib_calls.h
@@ -14,17 +14,18 @@
 // Max printable amount string size
 #define MAX_PRINTABLE_AMOUNT_SIZE 50
 
+
 // structure that should be send to specific coin application to get address
 typedef struct check_address_parameters_s {
     // IN
-    const unsigned char* const coin_configuration;
-    const unsigned char coin_configuration_length;
+    unsigned char* coin_configuration;
+    unsigned char coin_configuration_length;
     // serialized path, segwit, version prefix, hash used, dictionary etc.
     // fields and serialization format depends on spesific coin app
-    const unsigned char* const address_parameters;
-    const unsigned char address_parameters_length;
-    const char* const address_to_check;
-    const char* const extra_id_to_check;
+    unsigned char* address_parameters;
+    unsigned char address_parameters_length;
+    char* address_to_check;
+    char* extra_id_to_check;
     // OUT
     int result;
 } check_address_parameters_t;
@@ -32,25 +33,25 @@ typedef struct check_address_parameters_s {
 // structure that should be send to specific coin application to get printable amount
 typedef struct get_printable_amount_parameters_s {
     // IN
-    const unsigned char* const coin_configuration;
-    const unsigned char coin_configuration_length;
-    const unsigned char* const amount;
-    const unsigned char amount_length;
-    const bool is_fee;
+    unsigned char* coin_configuration;
+    unsigned char coin_configuration_length;
+    unsigned char* amount;
+    unsigned char amount_length;
+    bool is_fee;
     // OUT
     char printable_amount[MAX_PRINTABLE_AMOUNT_SIZE];
     // int result;
 } get_printable_amount_parameters_t;
 
 typedef struct create_transaction_parameters_s {
-    const unsigned char* const coin_configuration;
-    const unsigned char coin_configuration_length;
-    const unsigned char* const amount;
-    const unsigned char amount_length;
-    const unsigned char* const fee_amount;
-    const unsigned char fee_amount_length;
-    const char* const destination_address;
-    const char* const destination_address_extra_id;
+    unsigned char* coin_configuration;
+    unsigned char coin_configuration_length;
+    unsigned char* amount;
+    unsigned char amount_length;
+    unsigned char* fee_amount;
+    unsigned char fee_amount_length;
+    char* destination_address;
+    char* destination_address_extra_id;
 } create_transaction_parameters_t;
 
 #endif  // _SWAP_LIB_CALLS_H_

--- a/app/src/swap/swap_lib_calls.h
+++ b/app/src/swap/swap_lib_calls.h
@@ -1,0 +1,56 @@
+#ifndef _SWAP_LIB_CALLS_H_
+#define _SWAP_LIB_CALLS_H_
+
+#include "stdbool.h"
+
+// Swap commands macros
+// --------------------
+#define RUN_APPLICATION 1
+#define SIGN_TRANSACTION 2
+#define CHECK_ADDRESS 3
+#define GET_PRINTABLE_AMOUNT 4
+// --------------------
+
+// Max printable amount string size
+#define MAX_PRINTABLE_AMOUNT_SIZE 50
+
+// structure that should be send to specific coin application to get address
+typedef struct check_address_parameters_s {
+    // IN
+    const unsigned char* const coin_configuration;
+    const unsigned char coin_configuration_length;
+    // serialized path, segwit, version prefix, hash used, dictionary etc.
+    // fields and serialization format depends on spesific coin app
+    const unsigned char* const address_parameters;
+    const unsigned char address_parameters_length;
+    const char* const address_to_check;
+    const char* const extra_id_to_check;
+    // OUT
+    int result;
+} check_address_parameters_t;
+
+// structure that should be send to specific coin application to get printable amount
+typedef struct get_printable_amount_parameters_s {
+    // IN
+    const unsigned char* const coin_configuration;
+    const unsigned char coin_configuration_length;
+    const unsigned char* const amount;
+    const unsigned char amount_length;
+    const bool is_fee;
+    // OUT
+    char printable_amount[MAX_PRINTABLE_AMOUNT_SIZE];
+    // int result;
+} get_printable_amount_parameters_t;
+
+typedef struct create_transaction_parameters_s {
+    const unsigned char* const coin_configuration;
+    const unsigned char coin_configuration_length;
+    const unsigned char* const amount;
+    const unsigned char amount_length;
+    const unsigned char* const fee_amount;
+    const unsigned char fee_amount_length;
+    const char* const destination_address;
+    const char* const destination_address_extra_id;
+} create_transaction_parameters_t;
+
+#endif  // _SWAP_LIB_CALLS_H_


### PR DESCRIPTION
## DO NOT MERGE 
**Code submitted to help reproduce segfault bug in exchange when calling polkadot app for check address swap command**

Segfault occurs with nanos speculos (sdk 2.1.0). Exchange app and polkadot are compiled both with sdk 2.1.0.